### PR TITLE
Updates error handling in destroy logic

### DIFF
--- a/scripts/delete-resource-group.sh
+++ b/scripts/delete-resource-group.sh
@@ -43,6 +43,6 @@ if [ "$COUNT" -gt "0" ]; then
     echo "Deleted"
   fi
 else
-  echo "Resource Group Not Found"
-  exit 1;
+  echo "Resource group not found: ${RESOURCE_GROUP_NAME}" >&2
+  exit 0;
 fi


### PR DESCRIPTION
If the resource group cannot be found during the destroy process an error message is printed but it returns a 0 return code

closes #54

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>